### PR TITLE
c: Add Makefile for self-contained builds if YARA, OpenSSL are available

### DIFF
--- a/c/3rdparty/yara/endian.h
+++ b/c/3rdparty/yara/endian.h
@@ -1,0 +1,100 @@
+/*
+Copyright (c) 2016. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef YR_ENDIAN_H
+#define YR_ENDIAN_H
+
+#include <yara/integers.h>
+
+
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_bswap16)
+#    define yr_bswap16(x) __builtin_bswap16(x)
+#  endif
+#endif
+
+#if !defined(yr_bswap16) && defined(_MSC_VER)
+#  define yr_bswap16(x) _byteswap_ushort(x)
+#endif
+
+#if !defined(yr_bswap16)
+uint16_t _yr_bswap16(uint16_t x);
+# define yr_bswap16(x) _yr_bswap16(x)
+#endif
+
+
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_bswap32)
+#    define yr_bswap32(x) __builtin_bswap32(x)
+#  endif
+#endif
+
+#if !defined(yr_bswap32) && defined(_MSC_VER)
+#  define yr_bswap32(x) _byteswap_ulong(x)
+#endif
+
+#if !defined(yr_bswap32)
+uint32_t _yr_bswap32(uint32_t x);
+#define yr_bswap32(x) _yr_bswap32(x)
+#endif
+
+
+#if defined(__has_builtin)
+#  if __has_builtin(__builtin_bswap64)
+#    define yr_bswap64(x) __builtin_bswap64(x)
+#  endif
+#endif
+
+#if !defined(yr_bswap64) && defined(_MSC_VER)
+#  define yr_bswap64(x) _byteswap_uint64(x)
+#endif
+
+#if !defined(yr_bswap64)
+uint64_t _yr_bswap64(uint64_t x);
+#define yr_bswap64(x) _yr_bswap64(x)
+#endif
+
+
+#if defined(WORDS_BIGENDIAN)
+#define yr_le16toh(x) yr_bswap16(x)
+#define yr_le32toh(x) yr_bswap32(x)
+#define yr_le64toh(x) yr_bswap64(x)
+#define yr_be16toh(x) (x)
+#define yr_be32toh(x) (x)
+#define yr_be64toh(x) (x)
+#else
+#define yr_le16toh(x) (x)
+#define yr_le32toh(x) (x)
+#define yr_le64toh(x) (x)
+#define yr_be16toh(x) yr_bswap16(x)
+#define yr_be32toh(x) yr_bswap32(x)
+#define yr_be64toh(x) yr_bswap64(x)
+#endif
+
+#endif

--- a/c/3rdparty/yara/pe.h
+++ b/c/3rdparty/yara/pe.h
@@ -1,0 +1,563 @@
+/*
+Copyright (c) 2013. The YARA Authors. All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef YR_PE_H
+#define YR_PE_H
+
+#include <yara/endian.h>
+#include <yara/types.h>
+
+#pragma pack(push, 1)
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <windows.h>
+
+// PKCS7_SIGNER_INFO is defined by wincrypt.h, but it conflicts with a type
+// defined in openssl/pkcs7.h which is used in pe.c. Let's undefine the macro.
+#undef PKCS7_SIGNER_INFO
+
+// These definitions are not present in older Windows headers.
+
+#ifndef IMAGE_FILE_MACHINE_ARMNT
+#define IMAGE_FILE_MACHINE_ARMNT             0x01c4
+#endif
+
+#ifndef IMAGE_FILE_MACHINE_ARM64
+#define IMAGE_FILE_MACHINE_ARM64             0xaa64
+#endif
+
+
+
+#else
+
+#include <stdlib.h>
+
+#include <yara/integers.h>
+
+typedef uint8_t   BYTE;
+typedef uint16_t  WORD;
+typedef uint32_t  DWORD;
+typedef int32_t   LONG;
+typedef uint32_t  ULONG;
+typedef uint64_t  ULONGLONG;
+
+
+#define FIELD_OFFSET(type, field)    ((size_t)&(((type *)0)->field))
+
+#ifndef _MAC
+
+#define IMAGE_DOS_SIGNATURE                 0x5A4D      // MZ
+#define IMAGE_OS2_SIGNATURE                 0x454E      // NE
+#define IMAGE_OS2_SIGNATURE_LE              0x454C      // LE
+#define IMAGE_VXD_SIGNATURE                 0x454C      // LE
+#define IMAGE_NT_SIGNATURE                  0x00004550  // PE00
+
+#else
+
+#define IMAGE_DOS_SIGNATURE                 0x4D5A      // MZ
+#define IMAGE_OS2_SIGNATURE                 0x4E45      // NE
+#define IMAGE_OS2_SIGNATURE_LE              0x4C45      // LE
+#define IMAGE_NT_SIGNATURE                  0x50450000  // PE00
+
+#endif
+
+#pragma pack(push, 2)
+
+typedef struct _IMAGE_DOS_HEADER {      // DOS .EXE header
+    WORD   e_magic;                     // Magic number
+    WORD   e_cblp;                      // Bytes on last page of file
+    WORD   e_cp;                        // Pages in file
+    WORD   e_crlc;                      // Relocations
+    WORD   e_cparhdr;                   // Size of header in paragraphs
+    WORD   e_minalloc;                  // Minimum extra paragraphs needed
+    WORD   e_maxalloc;                  // Maximum extra paragraphs needed
+    WORD   e_ss;                        // Initial (relative) SS value
+    WORD   e_sp;                        // Initial SP value
+    WORD   e_csum;                      // Checksum
+    WORD   e_ip;                        // Initial IP value
+    WORD   e_cs;                        // Initial (relative) CS value
+    WORD   e_lfarlc;                    // File address of relocation table
+    WORD   e_ovno;                      // Overlay number
+    WORD   e_res[4];                    // Reserved words
+    WORD   e_oemid;                     // OEM identifier (for e_oeminfo)
+    WORD   e_oeminfo;                   // OEM information; e_oemid specific
+    WORD   e_res2[10];                  // Reserved words
+    LONG   e_lfanew;                    // File address of new exe header
+  } IMAGE_DOS_HEADER, *PIMAGE_DOS_HEADER;
+
+#pragma pack(pop)
+
+//
+// File header format.
+//
+
+#pragma pack(push,4)
+
+typedef struct _IMAGE_FILE_HEADER {
+    WORD    Machine;
+    WORD    NumberOfSections;
+    DWORD   TimeDateStamp;
+    DWORD   PointerToSymbolTable;
+    DWORD   NumberOfSymbols;
+    WORD    SizeOfOptionalHeader;
+    WORD    Characteristics;
+} IMAGE_FILE_HEADER, *PIMAGE_FILE_HEADER;
+
+
+
+#define IMAGE_SIZEOF_FILE_HEADER             20
+
+
+#define IMAGE_FILE_RELOCS_STRIPPED           0x0001  // Relocation info stripped from file.
+#define IMAGE_FILE_EXECUTABLE_IMAGE          0x0002  // File is executable  (i.e. no unresolved external references).
+#define IMAGE_FILE_LINE_NUMS_STRIPPED        0x0004  // Line numbers stripped from file.
+#define IMAGE_FILE_LOCAL_SYMS_STRIPPED       0x0008  // Local symbols stripped from file.
+#define IMAGE_FILE_AGGRESIVE_WS_TRIM         0x0010  // Aggressively trim working set
+#define IMAGE_FILE_LARGE_ADDRESS_AWARE       0x0020  // App can handle >2gb addresses
+#define IMAGE_FILE_BYTES_REVERSED_LO         0x0080  // Bytes of machine word are reversed.
+#define IMAGE_FILE_32BIT_MACHINE             0x0100  // 32 bit word machine.
+#define IMAGE_FILE_DEBUG_STRIPPED            0x0200  // Debugging info stripped from file in .DBG file
+#define IMAGE_FILE_REMOVABLE_RUN_FROM_SWAP   0x0400  // If Image is on removable media, copy and run from the swap file.
+#define IMAGE_FILE_NET_RUN_FROM_SWAP         0x0800  // If Image is on Net, copy and run from the swap file.
+#define IMAGE_FILE_SYSTEM                    0x1000  // System File.
+#define IMAGE_FILE_DLL                       0x2000  // File is a DLL.
+#define IMAGE_FILE_UP_SYSTEM_ONLY            0x4000  // File should only be run on a UP machine
+#define IMAGE_FILE_BYTES_REVERSED_HI         0x8000  // Bytes of machine word are reversed.
+
+
+#define IMAGE_FILE_MACHINE_UNKNOWN           0x0000
+#define IMAGE_FILE_MACHINE_AM33              0x01d3
+#define IMAGE_FILE_MACHINE_AMD64             0x8664
+#define IMAGE_FILE_MACHINE_ARM               0x01c0
+#define IMAGE_FILE_MACHINE_ARMNT             0x01c4
+#define IMAGE_FILE_MACHINE_ARM64             0xaa64
+#define IMAGE_FILE_MACHINE_EBC               0x0ebc
+#define IMAGE_FILE_MACHINE_I386              0x014c
+#define IMAGE_FILE_MACHINE_IA64              0x0200
+#define IMAGE_FILE_MACHINE_M32R              0x9041
+#define IMAGE_FILE_MACHINE_MIPS16            0x0266
+#define IMAGE_FILE_MACHINE_MIPSFPU           0x0366
+#define IMAGE_FILE_MACHINE_MIPSFPU16         0x0466
+#define IMAGE_FILE_MACHINE_POWERPC           0x01f0
+#define IMAGE_FILE_MACHINE_POWERPCFP         0x01f1
+#define IMAGE_FILE_MACHINE_R4000             0x0166
+#define IMAGE_FILE_MACHINE_SH3               0x01a2
+#define IMAGE_FILE_MACHINE_SH3DSP            0x01a3
+#define IMAGE_FILE_MACHINE_SH4               0x01a6
+#define IMAGE_FILE_MACHINE_SH5               0x01a8
+#define IMAGE_FILE_MACHINE_THUMB             0x01c2
+#define IMAGE_FILE_MACHINE_WCEMIPSV2         0x0169
+
+// Section characteristics
+#define IMAGE_SCN_CNT_CODE                   0x00000020
+#define IMAGE_SCN_CNT_INITIALIZED_DATA       0x00000040
+#define IMAGE_SCN_CNT_UNINITIALIZED_DATA     0x00000080
+#define IMAGE_SCN_GPREL                      0x00008000
+#define IMAGE_SCN_MEM_16BIT                  0x00020000
+#define IMAGE_SCN_LNK_NRELOC_OVFL            0x01000000
+#define IMAGE_SCN_MEM_DISCARDABLE            0x02000000
+#define IMAGE_SCN_MEM_NOT_CACHED             0x04000000
+#define IMAGE_SCN_MEM_NOT_PAGED              0x08000000
+#define IMAGE_SCN_MEM_SHARED                 0x10000000
+#define IMAGE_SCN_MEM_EXECUTE                0x20000000
+#define IMAGE_SCN_MEM_READ                   0x40000000
+#define IMAGE_SCN_MEM_WRITE                  0x80000000
+
+//
+// Directory format.
+//
+
+typedef struct _IMAGE_DATA_DIRECTORY {
+    DWORD   VirtualAddress;
+    DWORD   Size;
+} IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
+
+#define IMAGE_NUMBEROF_DIRECTORY_ENTRIES    16
+
+
+#define IMAGE_DIRECTORY_ENTRY_EXPORT          0   // Export Directory
+#define IMAGE_DIRECTORY_ENTRY_IMPORT          1   // Import Directory
+#define IMAGE_DIRECTORY_ENTRY_RESOURCE        2   // Resource Directory
+#define IMAGE_DIRECTORY_ENTRY_EXCEPTION       3   // Exception Directory
+#define IMAGE_DIRECTORY_ENTRY_SECURITY        4   // Security Directory
+#define IMAGE_DIRECTORY_ENTRY_BASERELOC       5   // Base Relocation Table
+#define IMAGE_DIRECTORY_ENTRY_DEBUG           6   // Debug Directory
+#define IMAGE_DIRECTORY_ENTRY_COPYRIGHT       7   // (X86 usage)
+#define IMAGE_DIRECTORY_ENTRY_ARCHITECTURE    7   // Architecture Specific Data
+#define IMAGE_DIRECTORY_ENTRY_GLOBALPTR       8   // RVA of GP
+#define IMAGE_DIRECTORY_ENTRY_TLS             9   // TLS Directory
+#define IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG    10   // Load Configuration Directory
+#define IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT   11   // Bound Import Directory in headers
+#define IMAGE_DIRECTORY_ENTRY_IAT            12   // Import Address Table
+#define IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT   13   // Delay Load Import Descriptors
+#define IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR 14   // COM Runtime descriptor
+
+
+//
+// Optional header format.
+//
+
+typedef struct _IMAGE_OPTIONAL_HEADER32 {
+    WORD Magic;
+    BYTE MajorLinkerVersion;
+    BYTE MinorLinkerVersion;
+    DWORD SizeOfCode;
+    DWORD SizeOfInitializedData;
+    DWORD SizeOfUninitializedData;
+    DWORD AddressOfEntryPoint;
+    DWORD BaseOfCode;
+    DWORD BaseOfData;
+    DWORD ImageBase;
+    DWORD SectionAlignment;
+    DWORD FileAlignment;
+    WORD MajorOperatingSystemVersion;
+    WORD MinorOperatingSystemVersion;
+    WORD MajorImageVersion;
+    WORD MinorImageVersion;
+    WORD MajorSubsystemVersion;
+    WORD MinorSubsystemVersion;
+    DWORD Win32VersionValue;
+    DWORD SizeOfImage;
+    DWORD SizeOfHeaders;
+    DWORD CheckSum;
+    WORD Subsystem;
+    WORD DllCharacteristics;
+    DWORD SizeOfStackReserve;
+    DWORD SizeOfStackCommit;
+    DWORD SizeOfHeapReserve;
+    DWORD SizeOfHeapCommit;
+    DWORD LoaderFlags;
+    DWORD NumberOfRvaAndSizes;
+    IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+
+} IMAGE_OPTIONAL_HEADER32, *PIMAGE_OPTIONAL_HEADER32;
+
+
+typedef struct _IMAGE_OPTIONAL_HEADER64 {
+    WORD Magic;
+    BYTE MajorLinkerVersion;
+    BYTE MinorLinkerVersion;
+    DWORD SizeOfCode;
+    DWORD SizeOfInitializedData;
+    DWORD SizeOfUninitializedData;
+    DWORD AddressOfEntryPoint;
+    DWORD BaseOfCode;
+    ULONGLONG ImageBase;
+    DWORD SectionAlignment;
+    DWORD FileAlignment;
+    WORD MajorOperatingSystemVersion;
+    WORD MinorOperatingSystemVersion;
+    WORD MajorImageVersion;
+    WORD MinorImageVersion;
+    WORD MajorSubsystemVersion;
+    WORD MinorSubsystemVersion;
+    DWORD Win32VersionValue;
+    DWORD SizeOfImage;
+    DWORD SizeOfHeaders;
+    DWORD CheckSum;
+    WORD Subsystem;
+    WORD DllCharacteristics;
+    ULONGLONG SizeOfStackReserve;
+    ULONGLONG SizeOfStackCommit;
+    ULONGLONG SizeOfHeapReserve;
+    ULONGLONG SizeOfHeapCommit;
+    DWORD LoaderFlags;
+    DWORD NumberOfRvaAndSizes;
+    IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+
+} IMAGE_OPTIONAL_HEADER64, *PIMAGE_OPTIONAL_HEADER64;
+
+
+#define IMAGE_NT_OPTIONAL_HDR32_MAGIC      0x10b
+#define IMAGE_NT_OPTIONAL_HDR64_MAGIC      0x20b
+
+
+typedef struct _IMAGE_NT_HEADERS32 {
+    DWORD Signature;
+    IMAGE_FILE_HEADER FileHeader;
+    IMAGE_OPTIONAL_HEADER32 OptionalHeader;
+
+} IMAGE_NT_HEADERS32, *PIMAGE_NT_HEADERS32;
+
+
+typedef struct _IMAGE_NT_HEADERS64 {
+    DWORD Signature;
+    IMAGE_FILE_HEADER FileHeader;
+    IMAGE_OPTIONAL_HEADER64 OptionalHeader;
+
+} IMAGE_NT_HEADERS64, *PIMAGE_NT_HEADERS64;
+
+// IMAGE_FIRST_SECTION doesn't need 32/64 versions since the file header is
+// the same either way.
+
+#define IMAGE_FIRST_SECTION( ntheader ) ((PIMAGE_SECTION_HEADER) \
+    ((BYTE*)ntheader + \
+     FIELD_OFFSET( IMAGE_NT_HEADERS32, OptionalHeader ) + \
+     yr_le16toh(((PIMAGE_NT_HEADERS32)(ntheader))->FileHeader.SizeOfOptionalHeader) \
+    ))
+
+// Subsystem Values
+
+#define IMAGE_SUBSYSTEM_UNKNOWN                          0
+#define IMAGE_SUBSYSTEM_NATIVE                           1
+#define IMAGE_SUBSYSTEM_WINDOWS_GUI                      2
+#define IMAGE_SUBSYSTEM_WINDOWS_CUI                      3
+#define IMAGE_SUBSYSTEM_OS2_CUI                          5
+#define IMAGE_SUBSYSTEM_POSIX_CUI                        7
+#define IMAGE_SUBSYSTEM_NATIVE_WINDOWS                   8
+#define IMAGE_SUBSYSTEM_WINDOWS_CE_GUI                   9
+#define IMAGE_SUBSYSTEM_EFI_APPLICATION                 10
+#define IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER         11
+#define IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER              12
+#define IMAGE_SUBSYSTEM_EFI_ROM_IMAGE                   13
+#define IMAGE_SUBSYSTEM_XBOX                            14
+#define IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION        16
+
+// DllCharacteristics values
+
+#define IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE           0x0040
+#define IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY        0x0080
+#define IMAGE_DLLCHARACTERISTICS_NX_COMPAT              0x0100
+#define IMAGE_DLLCHARACTERISTICS_NO_ISOLATION           0x0200
+#define IMAGE_DLLCHARACTERISTICS_NO_SEH                 0x0400
+#define IMAGE_DLLCHARACTERISTICS_NO_BIND                0x0800
+#define IMAGE_DLLCHARACTERISTICS_WDM_DRIVER             0x2000
+#define IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE  0x8000
+
+//
+// Section header format.
+//
+
+#define IMAGE_SIZEOF_SHORT_NAME              8
+
+typedef struct _IMAGE_SECTION_HEADER {
+    BYTE    Name[IMAGE_SIZEOF_SHORT_NAME];
+    union {
+            DWORD   PhysicalAddress;
+            DWORD   VirtualSize;
+    } Misc;
+    DWORD   VirtualAddress;
+    DWORD   SizeOfRawData;
+    DWORD   PointerToRawData;
+    DWORD   PointerToRelocations;
+    DWORD   PointerToLinenumbers;
+    WORD    NumberOfRelocations;
+    WORD    NumberOfLinenumbers;
+    DWORD   Characteristics;
+
+} IMAGE_SECTION_HEADER, *PIMAGE_SECTION_HEADER;
+
+#define IMAGE_SIZEOF_SECTION_HEADER          40
+
+
+typedef struct _IMAGE_EXPORT_DIRECTORY {
+    DWORD Characteristics;
+    DWORD TimeDateStamp;
+    WORD  MajorVersion;
+    WORD  MinorVersion;
+    DWORD Name;
+    DWORD Base;
+    DWORD NumberOfFunctions;
+    DWORD NumberOfNames;
+    DWORD AddressOfFunctions;
+    DWORD AddressOfNames;
+    DWORD AddressOfNameOrdinals;
+} IMAGE_EXPORT_DIRECTORY, *PIMAGE_EXPORT_DIRECTORY;
+
+
+typedef struct _IMAGE_IMPORT_DESCRIPTOR {
+    union {
+        DWORD Characteristics;
+        DWORD OriginalFirstThunk;
+    } ;
+    DWORD TimeDateStamp;
+    DWORD ForwarderChain;
+    DWORD Name;
+    DWORD FirstThunk;
+
+} IMAGE_IMPORT_DESCRIPTOR, *PIMAGE_IMPORT_DESCRIPTOR;
+
+
+typedef struct _IMAGE_IMPORT_BY_NAME {
+  WORD Hint;
+  BYTE Name[1];
+
+} IMAGE_IMPORT_BY_NAME, *PIMAGE_IMPORT_BY_NAME;
+
+typedef struct _IMAGE_THUNK_DATA32 {
+  union {
+    DWORD ForwarderString;
+    DWORD Function;
+    DWORD Ordinal;
+    DWORD AddressOfData;
+  } u1;
+
+} IMAGE_THUNK_DATA32, *PIMAGE_THUNK_DATA32;
+
+
+#define IMAGE_ORDINAL_FLAG32  0x80000000
+#define IMAGE_ORDINAL_FLAG64  0x8000000000000000L
+
+typedef struct _IMAGE_THUNK_DATA64 {
+  union {
+    ULONGLONG ForwarderString;
+    ULONGLONG Function;
+    ULONGLONG Ordinal;
+    ULONGLONG AddressOfData;
+  } u1;
+
+} IMAGE_THUNK_DATA64, *PIMAGE_THUNK_DATA64;
+
+
+typedef struct _IMAGE_RESOURCE_DIRECTORY_ENTRY {
+    DWORD Name;
+    DWORD OffsetToData;
+} IMAGE_RESOURCE_DIRECTORY_ENTRY, *PIMAGE_RESOURCE_DIRECTORY_ENTRY;
+
+
+ typedef struct _IMAGE_RESOURCE_DATA_ENTRY {
+    DWORD OffsetToData;
+    DWORD Size;
+    DWORD CodePage;
+    DWORD Reserved;
+ } IMAGE_RESOURCE_DATA_ENTRY,*PIMAGE_RESOURCE_DATA_ENTRY;
+
+
+typedef struct _IMAGE_RESOURCE_DIRECTORY {
+    DWORD Characteristics;
+    DWORD TimeDateStamp;
+    WORD  MajorVersion;
+    WORD  MinorVersion;
+    WORD  NumberOfNamedEntries;
+    WORD  NumberOfIdEntries;
+} IMAGE_RESOURCE_DIRECTORY, *PIMAGE_RESOURCE_DIRECTORY;
+
+#define IMAGE_DEBUG_TYPE_UNKNOWN                         0
+#define IMAGE_DEBUG_TYPE_COFF                            1
+#define IMAGE_DEBUG_TYPE_CODEVIEW                        2
+#define IMAGE_DEBUG_TYPE_FPO                             3
+#define IMAGE_DEBUG_TYPE_MISC                            4
+#define IMAGE_DEBUG_TYPE_EXCEPTION                       5
+#define IMAGE_DEBUG_TYPE_FIXUP                           6
+#define IMAGE_DEBUG_TYPE_BORLAND                         9
+
+typedef struct _IMAGE_DEBUG_DIRECTORY {
+    DWORD Characteristics;
+    DWORD TimeDateStamp;
+    WORD  MajorVersion;
+    WORD  MinorVersion;
+    DWORD Type;
+    DWORD SizeOfData;
+    DWORD AddressOfRawData;
+    DWORD PointerToRawData;
+} IMAGE_DEBUG_DIRECTORY, *PIMAGE_DEBUG_DIRECTORY;
+
+#pragma pack(pop)
+
+#endif  // _WIN32
+
+#define CVINFO_PDB70_CVSIGNATURE                0x53445352 // "RSDS"
+#define CVINFO_PDB20_CVSIGNATURE                0x3031424e // "NB10"
+
+typedef struct _CV_HEADER {
+    DWORD dwSignature;
+    DWORD dwOffset;
+} CV_HEADER, *PCV_HEADER;
+
+typedef struct _CV_INFO_PDB20 {
+    CV_HEADER CvHeader;
+    DWORD dwSignature;
+    DWORD dwAge;
+    BYTE PdbFileName[1];
+} CV_INFO_PDB20, *PCV_INFO_PDB20;
+
+typedef struct _CV_INFO_PDB70 {
+    DWORD CvSignature;
+    DWORD Signature[4];
+    DWORD Age;
+    BYTE  PdbFileName[1];
+} CV_INFO_PDB70, *PCV_INFO_PDB70;
+
+typedef struct _VERSION_INFO {
+    WORD   Length;
+    WORD   ValueLength;
+    WORD   Type;
+    char   Key[0];
+} VERSION_INFO, *PVERSION_INFO;
+
+
+#define MAX_PE_CERTS 16
+
+#define WIN_CERT_REVISION_1_0 0x0100
+#define WIN_CERT_REVISION_2_0 0x0200
+
+#define WIN_CERT_TYPE_X509             0x0001
+#define WIN_CERT_TYPE_PKCS_SIGNED_DATA 0x0002
+#define WIN_CERT_TYPE_RESERVED_1       0x0003
+#define WIN_CERT_TYPE_TS_STACK_SIGNED  0x0004
+
+#define WIN_CERTIFICATE_HEADER_SIZE    8
+
+typedef struct _WIN_CERTIFICATE {
+    DWORD Length;
+    WORD  Revision;
+    WORD  CertificateType;
+    BYTE  Certificate[0];
+} WIN_CERTIFICATE, *PWIN_CERTIFICATE;
+
+#define SPC_NESTED_SIGNATURE_OBJID  "1.3.6.1.4.1.311.2.4.1"
+
+
+//
+// Rich signature.
+// http://www.ntcore.com/files/richsign.htm
+//
+
+#define RICH_VERSION_ID(id_version) (id_version >> 16)
+#define RICH_VERSION_VERSION(id_version) (id_version & 0xFFFF)
+
+typedef struct _RICH_VERSION_INFO {
+    DWORD id_version; //tool id and version (use RICH_VERSION_ID and RICH_VERSION_VERSION macros)
+    DWORD times; //number of times this tool was used
+} RICH_VERSION_INFO, *PRICH_VERSION_INFO;
+
+typedef struct _RICH_SIGNATURE {
+    DWORD dans;
+    DWORD key1;
+    DWORD key2;
+    DWORD key3;
+    RICH_VERSION_INFO versions[0];
+} RICH_SIGNATURE, *PRICH_SIGNATURE;
+
+#define RICH_DANS 0x536e6144 // "DanS"
+#define RICH_RICH 0x68636952 // "Rich"
+
+
+#pragma pack(pop)
+#endif

--- a/c/3rdparty/yara/pe_utils.h
+++ b/c/3rdparty/yara/pe_utils.h
@@ -1,0 +1,108 @@
+#ifndef YR_PE_UTILS_H
+#define YR_PE_UTILS_H
+
+#include <yara/pe.h>
+
+#define MAX_PE_SECTIONS              96
+
+
+#define IS_64BITS_PE(pe) \
+    (yr_le16toh(pe->header64->OptionalHeader.Magic) == IMAGE_NT_OPTIONAL_HDR64_MAGIC)
+
+
+#define OptionalHeader(pe,field)                \
+  (IS_64BITS_PE(pe) ?                           \
+   pe->header64->OptionalHeader.field :         \
+   pe->header->OptionalHeader.field)
+
+
+//
+// Imports are stored in a linked list. Each node (IMPORTED_DLL) contains the
+// name of the DLL and a pointer to another linked list of
+// IMPORT_EXPORT_FUNCTION structures containing the details of imported
+// functions.
+//
+
+typedef struct _IMPORTED_DLL
+{
+  char *name;
+
+  struct _IMPORT_FUNCTION *functions;
+  struct _IMPORTED_DLL *next;
+
+} IMPORTED_DLL, *PIMPORTED_DLL;
+
+
+//
+// This is used to track imported and exported functions. The "has_ordinal"
+// field is only used in the case of imports as those are optional. Every export
+// has an ordinal so we don't need the field there, but in the interest of
+// keeping duplicate code to a minimum we use this function for both imports and
+// exports.
+//
+
+typedef struct _IMPORT_FUNCTION
+{
+  char *name;
+  uint8_t has_ordinal;
+  uint16_t ordinal;
+
+  struct _IMPORT_FUNCTION *next;
+
+} IMPORT_FUNCTION, *PIMPORT_FUNCTION;
+
+
+typedef struct _PE
+{
+  const uint8_t* data;
+  size_t data_size;
+
+  union {
+    PIMAGE_NT_HEADERS32 header;
+    PIMAGE_NT_HEADERS64 header64;
+  };
+
+  YR_HASH_TABLE* hash_table;
+  YR_OBJECT* object;
+  IMPORTED_DLL* imported_dlls;
+
+  uint32_t resources;
+
+} PE;
+
+
+#define fits_in_pe(pe, pointer, size) \
+    ((size_t) size <= pe->data_size && \
+     (uint8_t*) (pointer) >= pe->data && \
+     (uint8_t*) (pointer) <= pe->data + pe->data_size - size)
+
+#define struct_fits_in_pe(pe, pointer, struct_type) \
+    fits_in_pe(pe, pointer, sizeof(struct_type))
+
+
+PIMAGE_NT_HEADERS32 pe_get_header(
+    const uint8_t* data,
+    size_t data_size);
+
+
+PIMAGE_DATA_DIRECTORY pe_get_directory_entry(
+    PE* pe,
+    int entry);
+
+
+int64_t pe_rva_to_offset(
+    PE* pe,
+    uint64_t rva);
+
+
+char *ord_lookup(
+    char *dll,
+    uint16_t ord);
+
+
+#if HAVE_LIBCRYPTO
+#include <openssl/asn1.h>
+time_t ASN1_get_time_t(ASN1_TIME* time);
+#endif
+
+#endif

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,0 +1,17 @@
+CFLAGS = -Wall -Wpedantic -I./3rdparty
+
+CFLAGS += $(shell pkg-config --static --cflags yara libcrypto)
+LIBS   += $(shell pkg-config --static --libs yara libcrypto)
+
+all: gimphash
+
+gimphash: gimphash.o
+	$(CC) -static -o $@ $^ $(LIBS) 
+
+%.o: %.c
+	$(CC) $(CFLAGS) -o $@ -c $<
+
+clean:
+	rm -f gimphash *.o
+
+.PHONY: all clean

--- a/c/README.md
+++ b/c/README.md
@@ -2,12 +2,9 @@ Build
 -----
 
 The C version currently depends on libyara (for PE parsing) and OpenSSL
-(for SHA256 calculation).
+(for SHA256 calculation). `pkg-config` is used to locate header files and static libraries.
 
-Compile using:
-
-`CFLAGS=-I<path/to/yarasource>/libyara/include -I<path/to/opensslinstall>/include`
-`LDFLAGS=<path/to/opensslinstall>/lib64/libcrypto.a <path/to/yarainstall>/lib/libyara.a`
+Run `make` to compile.
 
 Restrictions
 ------------


### PR DESCRIPTION
We need to add some PE-specific YARA 4.0 headers because they are not
copied when using "make install".

(ABI-wise, things have not changed substantially between YARA 4.0 and
4.2.1, as far as I can tell.)